### PR TITLE
Added gcc to dockerfile, fixed bug for building docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR app/
 
 COPY requirements.txt requirements.txt
 
+RUN apk --update --upgrade add gcc musl-dev jpeg-dev zlib-dev libffi-dev cairo-dev pango-dev gdk-pixbuf-dev
 RUN pip3 install --upgrade pip setuptools wheel
 RUN pip3 install --no-warn-script-location --no-cache-dir -r requirements.txt
 


### PR DESCRIPTION
fixes issues with building the docker image because some build tools were needed like gcc.
thix fixes the error when Docker was trying to install the python dependencies:
```gcc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I/usr/local/include/python3.10 -c tgcrypto/aes256.c -o build/temp.linux-aarch64-cpython-310/tgcrypto/aes256.o
5.923       error: command 'gcc' failed: No such file or directory
5.923       [end of output]```
